### PR TITLE
feat: Update stat for object storage

### DIFF
--- a/cmd/byctl/cp.go
+++ b/cmd/byctl/cp.go
@@ -84,7 +84,7 @@ var cpCmd = &cli.Command{
 			}
 		}
 		if argsNum > 2 {
-			if err == nil && !dstObject.Mode.IsDir() {
+			if dstObject != nil && !dstObject.Mode.IsDir() {
 				fmt.Printf("cp: target '%s' is not a directory\n", dstKey)
 				return fmt.Errorf("cp: target '%s' is not a directory", dstKey)
 			}

--- a/cmd/byctl/cp.go
+++ b/cmd/byctl/cp.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"go.uber.org/zap"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/go-units"
 	"github.com/urfave/cli/v2"
 
 	"go.beyondstorage.io/beyond-ctl/operations"
-	"go.beyondstorage.io/v5/pairs"
 	"go.beyondstorage.io/v5/services"
 	"go.beyondstorage.io/v5/types"
 )
@@ -76,12 +74,12 @@ var cpCmd = &cli.Command{
 
 		dstSo := operations.NewSingleOperator(dst)
 
+		dstObject, err := dstSo.Stat(dstKey)
+		if err != nil && !errors.Is(err, services.ErrObjectNotExist) {
+			logger.Error("stat", zap.Error(err), zap.String("dst path", dstKey))
+			return err
+		}
 		if argsNum > 2 {
-			dstObject, err := dstSo.Stat(dstKey, pairs.WithObjectMode(types.ModeDir))
-			if err != nil && !errors.Is(err, services.ErrObjectNotExist) {
-				logger.Error("stat", zap.Error(err), zap.String("dst path", dstKey))
-				return err
-			}
 			if err == nil && !dstObject.Mode.IsDir() {
 				fmt.Printf("cp: target '%s' is not a directory\n", dstKey)
 				return fmt.Errorf("cp: target '%s' is not a directory", dstKey)
@@ -132,10 +130,6 @@ var cpCmd = &cli.Command{
 				continue
 			}
 
-			if c.Bool(cpFlagRecursive) && !strings.HasSuffix(srcKey, "/") {
-				srcKey += "/"
-			}
-
 			src, err := services.NewStoragerFromString(srcConn)
 			if err != nil {
 				logger.Error("init src storager", zap.Error(err), zap.String("conn string", srcConn))
@@ -150,10 +144,19 @@ var cpCmd = &cli.Command{
 				continue
 			}
 
-			size, ok := srcObject.GetContentLength()
-			if !ok {
-				logger.Error("can't get object content length", zap.String("path", srcKey))
+			if srcObject.Mode.IsDir() && !c.Bool(cpFlagRecursive) {
+				fmt.Printf("cp: -r not specified; omitting directory '%s'\n", srcKey)
 				continue
+			}
+
+			var size int64
+			if srcObject.Mode.IsRead() {
+				n, ok := srcObject.GetContentLength()
+				if !ok {
+					logger.Error("can't get object content length", zap.String("path", srcKey))
+					continue
+				}
+				size = n
 			}
 
 			do := operations.NewDualOperator(src, dst)
@@ -167,12 +170,12 @@ var cpCmd = &cli.Command{
 			do.WithWritePairs(writePairs...)
 
 			realDstKey := dstKey
-			if argsNum > 2 {
+			if argsNum > 2 || (dstObject != nil && dstObject.Mode.IsDir()) {
 				realDstKey = filepath.Join(dstKey, filepath.Base(srcKey))
 			}
 
 			var ch chan *operations.EmptyResult
-			if c.Bool(cpFlagRecursive) {
+			if c.Bool(cpFlagRecursive) && srcObject.Mode.IsDir() {
 				ch, err = do.CopyRecursively(srcKey, realDstKey, multipartThreshold)
 			} else if size < multipartThreshold {
 				ch, err = do.CopyFileViaWrite(srcKey, realDstKey, size)

--- a/cmd/byctl/cp.go
+++ b/cmd/byctl/cp.go
@@ -75,9 +75,13 @@ var cpCmd = &cli.Command{
 		dstSo := operations.NewSingleOperator(dst)
 
 		dstObject, err := dstSo.Stat(dstKey)
-		if err != nil && !errors.Is(err, services.ErrObjectNotExist) {
-			logger.Error("stat", zap.Error(err), zap.String("dst path", dstKey))
-			return err
+		if err != nil {
+			if errors.Is(err, services.ErrObjectNotExist) {
+				err = nil
+			} else {
+				logger.Error("stat", zap.Error(err), zap.String("dst path", dstKey))
+				return err
+			}
 		}
 		if argsNum > 2 {
 			if err == nil && !dstObject.Mode.IsDir() {

--- a/cmd/byctl/mv.go
+++ b/cmd/byctl/mv.go
@@ -113,9 +113,13 @@ var mvCmd = &cli.Command{
 		dstSo := operations.NewSingleOperator(dst)
 
 		dstObject, err := dstSo.Stat(dstKey)
-		if err != nil && !errors.Is(err, services.ErrObjectNotExist) {
-			logger.Error("stat", zap.Error(err), zap.String("dst path", dstKey))
-			return err
+		if err != nil {
+			if errors.Is(err, services.ErrObjectNotExist) {
+				err = nil
+			} else {
+				logger.Error("stat", zap.Error(err), zap.String("dst path", dstKey))
+				return err
+			}
 		}
 		if args > 2 {
 			if err == nil && !dstObject.Mode.IsDir() {

--- a/operations/stat.go
+++ b/operations/stat.go
@@ -1,11 +1,41 @@
 package operations
 
 import (
+	"errors"
+	"strings"
+
+	"go.beyondstorage.io/v5/pairs"
+	"go.beyondstorage.io/v5/services"
 	"go.beyondstorage.io/v5/types"
 )
 
-func (so *SingleOperator) Stat(path string, pairs ...types.Pair) (o *types.Object, err error) {
-	o, err = so.store.Stat(path, pairs...)
+func (so *SingleOperator) Stat(path string) (o *types.Object, err error) {
+	o, err = so.store.Stat(path)
+
+	if err != nil && errors.Is(err, services.ErrObjectNotExist) {
+		it, cerr := so.store.List(path, pairs.WithListMode(types.ListModeDir))
+		if cerr == nil {
+			for {
+				// FIXME: We should check if the directory exists by whether the object list is empty after bumping to the new version of services.
+				obj, cerr := it.Next()
+				if cerr != nil && errors.Is(cerr, types.IterateDone) {
+					break
+				}
+				if cerr != nil {
+					err = cerr
+					break
+				}
+				if (obj.Mode.IsDir() && strings.TrimSuffix(obj.Path, "/") == strings.TrimSuffix(path, "/")) ||
+					(!obj.Mode.IsDir() && strings.HasPrefix(obj.Path, strings.TrimSuffix(path, "/")+"/")) {
+					o = so.store.Create(path)
+					o.Mode = types.ModeDir
+					err = nil
+					break
+				}
+			}
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Refer to [hadoop-aliyun getFileStatus(Path path)](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystem.java) to update `stat` to make it work for object stores to get directory status.